### PR TITLE
feat: add get user permission api

### DIFF
--- a/src/decorators/no-cache-headers.decorator.ts
+++ b/src/decorators/no-cache-headers.decorator.ts
@@ -1,0 +1,9 @@
+import { applyDecorators, Header } from '@nestjs/common';
+
+export function NoCacheHeaders(): ReturnType<typeof applyDecorators> {
+  return applyDecorators(
+    Header('Cache-Control', 'no-cache, no-store'),
+    Header('Pragma', 'no-cache'),
+    Header('Expires', '0'),
+  );
+}

--- a/src/modules/authz/ability.factory.ts
+++ b/src/modules/authz/ability.factory.ts
@@ -16,6 +16,7 @@ export interface CaslPermission {
 
 type Permissions = {
   unconditionalAbilities: AppAbility;
+  rawUnconditionalPermissions: CaslPermission[];
 };
 
 @Injectable()
@@ -46,6 +47,7 @@ export class AbilityFactory {
 
     return {
       unconditionalAbilities: createMongoAbility(unconditionalPermissions),
+      rawUnconditionalPermissions: unconditionalPermissions,
     };
   }
 }

--- a/src/modules/authz/dto/permission.dto.ts
+++ b/src/modules/authz/dto/permission.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty, ApiResponseProperty } from '@nestjs/swagger';
+import { PermissionAction, PermissionSubject } from 'src/db/entities';
+
+export class CaslPermission {
+  @ApiResponseProperty({
+    enum: PermissionAction,
+  })
+  @ApiProperty({ enumName: 'PermissionAction' })
+  action: PermissionAction;
+
+  @ApiResponseProperty({
+    enum: PermissionSubject,
+  })
+  @ApiProperty({ enumName: 'PermissionSubject' })
+  subject: PermissionSubject;
+}

--- a/src/modules/organizations/users/dto/permissions-response.dto.ts
+++ b/src/modules/organizations/users/dto/permissions-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiResponseProperty } from '@nestjs/swagger';
+import { CaslPermission } from 'src/modules/authz/dto/permission.dto';
+
+export class GetUserPermissionsResponseDto {
+  @ApiResponseProperty({
+    type: [CaslPermission],
+  })
+  permissions: CaslPermission[];
+}

--- a/src/modules/organizations/users/users.controller.ts
+++ b/src/modules/organizations/users/users.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpStatus,
   ParseIntPipe,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { UsersService } from './users.service';
@@ -23,7 +24,9 @@ import { JwtAuthGuard } from 'src/modules/auth/jwt-auth.guard';
 import { OrganizationMemberGuard } from '../organization-member.guard';
 import { PermissionsGuard } from 'src/modules/authz/permissions.guard';
 import { CheckPermissions } from 'src/modules/authz/permissions.decorator';
-import { PermissionAction, PermissionSubject } from 'src/db/entities';
+import { PermissionAction, PermissionSubject, User } from 'src/db/entities';
+import { GetUserPermissionsResponseDto } from './dto/permissions-response.dto';
+import { NoCacheHeaders } from 'src/decorators/no-cache-headers.decorator';
 
 /**
  * whatever the string pass in controller decorator it will be appended to
@@ -129,5 +132,24 @@ export class UsersController {
     @Param('id', ParseIntPipe) userId: number,
   ): Promise<void> {
     await this.usersService.deleteByIdAndOrgId(organizationId, userId);
+  }
+
+  @Get('permissions')
+  @ApiOperation({
+    tags: ['Organization User'],
+    operationId: 'Get user permissions',
+    summary: "Get organization user's permissions",
+    description: "Get organization user's permissions",
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: [GetUserPermissionsResponseDto],
+  })
+  @NoCacheHeaders()
+  async getPermissions(
+    @Param('organizationId', ParseIntPipe) organizationId: number,
+    @Req() { user }: { user: User },
+  ): Promise<GetUserPermissionsResponseDto> {
+    return await this.usersService.getPermissions(organizationId, user);
   }
 }

--- a/src/modules/organizations/users/users.service.ts
+++ b/src/modules/organizations/users/users.service.ts
@@ -22,6 +22,8 @@ import { BulkInviteResponseDto } from './dto/bulk-invite-response.dto';
 import { UserOrganizationRepository } from 'src/db/repositories/user-organization.repository';
 import { CanNotDisableTheLastAdminException } from 'src/modules/common/exceptions/base.exception';
 import { Not } from 'typeorm';
+import { GetUserPermissionsResponseDto } from './dto/permissions-response.dto';
+import { AbilityFactory } from 'src/modules/authz/ability.factory';
 
 export interface UserAttributes {
   email: string;
@@ -36,6 +38,7 @@ export class UsersService {
     private readonly organizationRepository: OrganizationRepository,
     private readonly userOrganizationRepository: UserOrganizationRepository,
     private readonly userOrganizationRoleRepository: UserOrganizationRoleRepository,
+    readonly abilityFactory: AbilityFactory,
   ) {}
 
   async findByOrganization(
@@ -318,5 +321,17 @@ export class UsersService {
         throw new NotFoundException(`Role do not exist ${role.id}`);
       }
     });
+  }
+
+  async getPermissions(
+    organizationId: number,
+    user: User,
+  ): Promise<GetUserPermissionsResponseDto> {
+    const { rawUnconditionalPermissions } =
+      await this.abilityFactory.createForUser(user, organizationId);
+
+    return {
+      permissions: rawUnconditionalPermissions,
+    };
   }
 }


### PR DESCRIPTION
## Why
Close #16

## Changelog
- Add get user's permissions API endpoint

## How to test this change in local
<!-- As detailed as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in another services... -->

### Branches
- sushi: `develop`
<!-- - : `develop` -->

## Checklist
<!-- Strive to complete the checklist. Remove those that do not apply to your PR -->
- [x] Confirmed that the PR resolves / follows the linked issue instructions. <!-- epic design spec, bug report, etc -->
- [x] Provided enough context in PR / issue description for reviewers.
