### PR TITLE
feat: add organization expense & income by category

### DIFF
--- a/src/modules/organizations/projects/categories/dto/category-response.dto.ts
+++ b/src/modules/organizations/projects/categories/dto/category-response.dto.ts
@@ -13,11 +13,7 @@ export class CategoryResponseDto {
       this.totalSpent =
         category.invoices.reduce((acc, invoice) => {
           let sum = acc;
-          if (invoice.type === InvoiceType.EXPENSE) {
-            sum += parseFloat(
-              (invoice.total / invoice.exchangeRate).toFixed(2),
-            );
-          }
+          sum += parseFloat((invoice.total / invoice.exchangeRate).toFixed(2));
           return sum;
         }, 0) ?? 0;
     }

--- a/src/modules/organizations/statistics/dto/organization-statistics-response.dto.ts
+++ b/src/modules/organizations/statistics/dto/organization-statistics-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiResponseProperty } from '@nestjs/swagger';
 import { ProjectResponseDto } from '../../projects/dto/project-response.dto';
+import { IncomesAndExpensesByCategoryResponseDto } from '../../projects/statistics/dto/project-statistics-response.dto';
 
 export class OrganizationStatisticsResponseDto {
   @ApiResponseProperty({
@@ -73,6 +74,16 @@ export class OrganizationStatisticsResponseDto {
     example: [280, 200, 220, 180, 270, 250, 70, 90, 200, 150, 160, 100],
   })
   expensesByMonth: number[];
+
+  @ApiResponseProperty({
+    type: [IncomesAndExpensesByCategoryResponseDto],
+  })
+  incomesByCategory: IncomesAndExpensesByCategoryResponseDto[];
+
+  @ApiResponseProperty({
+    type: [IncomesAndExpensesByCategoryResponseDto],
+  })
+  expensesByCategory: IncomesAndExpensesByCategoryResponseDto[];
 
   @ApiResponseProperty({
     type: [ProjectResponseDto],

--- a/src/modules/organizations/statistics/statistics.service.ts
+++ b/src/modules/organizations/statistics/statistics.service.ts
@@ -43,6 +43,8 @@ export class StatisticsService {
       totalExpense,
       incomesByMonth,
       expensesByMonth,
+      incomesByCategory,
+      expensesByCategory,
       totalUncategorizedIncome,
       totalUncategorizedExpense,
       projects,
@@ -55,6 +57,14 @@ export class StatisticsService {
       this.invoiceRepository.calculateOrgTotalExpense(organizationId, search),
       this.invoiceRepository.calculateOrgIncomesByMonth(organizationId, search),
       this.invoiceRepository.calculateOrgExpensesByMonth(
+        organizationId,
+        search,
+      ),
+      this.invoiceRepository.calculateOrgIncomesByCategory(
+        organizationId,
+        search,
+      ),
+      this.invoiceRepository.calculateOrgExpensesByCategory(
         organizationId,
         search,
       ),
@@ -81,6 +91,8 @@ export class StatisticsService {
     organizationStatistics.totalExpense = totalExpense;
     organizationStatistics.incomesByMonth = incomesByMonth;
     organizationStatistics.expensesByMonth = expensesByMonth;
+    organizationStatistics.incomesByCategory = incomesByCategory;
+    organizationStatistics.expensesByCategory = expensesByCategory;
     organizationStatistics.totalUncategorizedIncome = totalUncategorizedIncome;
     organizationStatistics.totalUncategorizedExpense =
       totalUncategorizedExpense;


### PR DESCRIPTION
## Why
Close https://github.com/dylan751/sushi/issues/254

## Changelog
- Add statistics for org: Expense & income by category

## How to test this change in local
<!-- As detailed as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

### Branches
- sushi: https://github.com/dylan751/sushi/pull/255
<!-- - : `develop` -->
